### PR TITLE
Add appcast URL to support native Sketch updates

### DIFF
--- a/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
@@ -51,5 +51,6 @@
   "description" : "A variety of tricks for dealing with artboards.",
   "authorEmail" : "roman@nurik.net",
   "author" : "Roman Nurik",
+  "appcast": "https://api.sketchpacks.com/v1/plugins/net.nurik.roman.sketch.artboardtricks/appcast",
   "name" : "Artboard Tricks"
 }


### PR DESCRIPTION
Sketchpacks Appcast Documentation: https://docs.sketchpacks.com/developers/publishing/providing-plugin-updates.html