### PR TITLE
Magic: Rearrange and prefix at the same time

### DIFF
--- a/ArtboardTricks.sketchplugin/Contents/Sketch/add_number_identifiers_to_artboards.js
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/add_number_identifiers_to_artboards.js
@@ -76,7 +76,7 @@ function prependNumbersToArtboards(context) {
     var fullName = meta.artboard.name();
     var currentNamePath = fullName.substring(0, fullName.lastIndexOf('/') + 1);
     var currentName = fullName.slice(currentNamePath.length);
-    currentName = currentName.replace(/^.*[_]/, '').replace(/\s/g, '.').toLowerCase(); // added remove spaces + lowercase
+    currentName = currentName.replace(/^.*[_]/, '').replace(/\s/g, '.'); // added remove spaces + lowercase
 
     // add prefix to the name
     meta.artboard.setName(currentNamePath + prefix + '_' +  currentName);

--- a/ArtboardTricks.sketchplugin/Contents/Sketch/both.js
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/both.js
@@ -1,6 +1,6 @@
 
-@import 'add_number_identifiers_to_artboards.cocoascript'
-@import 'rearrange_artboards_into_grid.cocoascript'
+@import 'add_number_identifiers_to_artboards.js'
+@import 'rearrange_artboards_into_grid.js'
 var onRun = function(context) {
   rearrangeArtboardsIntoGrid(context);
   prependNumbersToArtboards(context);

--- a/ArtboardTricks.sketchplugin/Contents/Sketch/both.js
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/both.js
@@ -1,0 +1,7 @@
+
+@import 'add_number_identifiers_to_artboards.cocoascript'
+@import 'rearrange_artboards_into_grid.cocoascript'
+var onRun = function(context) {
+  rearrangeArtboardsIntoGrid(context);
+  prependNumbersToArtboards(context);
+};

--- a/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
@@ -1,6 +1,13 @@
 {
   "commands" : [
     {
+      "script" : "both.js",
+      "handler" : "onRun",
+      "name" : "Magic",
+      "shortcut" : "cmd º",
+      "identifier" : "select_artboards_containing_selection_and_set_rearrange_spacing"
+    },
+    {
       "script" : "select_artboards_containing_selection.js",
       "handler" : "onRun",
       "shortcut" : "ctrl cmd option s",

--- a/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
+++ b/ArtboardTricks.sketchplugin/Contents/Sketch/manifest.json
@@ -43,6 +43,8 @@
   ],
   "menu" : {
     "items" : [
+      "select_artboards_containing_selection_and_set_rearrange_spacing",
+      "-",
       "select_artboards_containing_selection",
       "-",
       "rearrange_artboards_into_grid",

--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ the current position of each artboard.
 
 ## Prefix Artboard Names With Numbers
 
-Prefixes each artboard in your page with a number such as 102, 300, 517, etc. based on X and Y position.
-This is designed to be used with the "Rearrange Artboards Into Grid" command. The first digit is the row,
-the second 2 digits are the column, like so:
+Prefixes each artboard in your page with a number such as 01.02, 03.00, 05.17, etc. based on X and Y position.
+
+This is designed to be used with the "Rearrange Artboards Into Grid" command. The first two digit are the row, the second 2 digits are the column, like so:
 
 ```
-100 101 102
-200 201
-300 301 302 303 304
+00.00 00.01 00.02
+
+01.00 01.01 00.02
+
+02.00 02.01 00.02
 ```
+
+## Magic
+
+With these command you can trigger both 'Rearrange Artboards Into Grid' and 'Prefix Artboard Names With Numers' in one single shortcut with '⌘ + <'


### PR DESCRIPTION
Hi, here at [Aerolab](aerolab.co) we've been using this plugin for a couple of months and we think it's great, it helped us gain some time and improve collaboration between designers and devs working in the same project.
We wanted to do both commands at the same time to gain a little bit of time and commodity when launching the shortcuts.
We also had some troubles with big projects when working with invision, because at the 10th row everything was renamed and the prototype stopped working. That's why we wanted to differentiate rows from columns (like RR.CC - 02.05) to have more space to work with.