### PR TITLE
Fix release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can install the plugin with Sketch Runner.
   <img src="http://bit.ly/RunnerBadgeBlue" width="160">
 </a>
 
-Alternatively, just download the latest [release](https://github.com/romannurik/Sketch-FlowExporter/releases) and double-click the `.sketchplugin` file to install.
+Alternatively, just download the latest [release](https://github.com/romannurik/Sketch-ArtboardTricks/releases) and double-click the `.sketchplugin` file to install.
 
 # The Commands
 


### PR DESCRIPTION
Original release link brings to https://github.com/romannurik/Sketch-FlowExporter/releases
Updated link brings to https://github.com/romannurik/Sketch-ArtboardTricks/releases
But hey, I see a new plugin that I might use due to the wrong link